### PR TITLE
Add repeat support

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
                 }
             ]
         },
-        "keybindings":[
+        "keybindings": [
             {
                 "command": "p2tas-lang.relativeFromAbsoluteTick",
                 "key": "ctrl+shift+t",


### PR DESCRIPTION
The hover provider and the tick insert command will now take repeat
statements into account. If you use them from inside a repeat block,
the hover provider will additionally show you the tick at the
start of the loop and the tick insert command will for now error out.